### PR TITLE
Mark `simulator` as a cython package in `setup.py`

### DIFF
--- a/pyloric/simulator.pyx
+++ b/pyloric/simulator.pyx
@@ -10,6 +10,9 @@ import time
 import cython
 cimport cython
 
+# to initialize numpy C API for multiarray. otherwise, you get the error below
+# ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).
+np.import_array()
 
 ctypedef double dtype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "Cython", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ import io
 import os
 import sys
 from shutil import rmtree
+from Cython.Build import cythonize
+import numpy as np
 
 from setuptools import find_packages, setup, Command
 
@@ -50,6 +52,8 @@ setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=find_packages(),
+    ext_modules=cythonize("pyloric/simulator.pyx"),
+    include_dirs=[np.get_include()],
     install_requires=REQUIRED,
     include_package_data=True,
     license="AGPLv3",


### PR DESCRIPTION
Hiya

This PR proposes to mark `pyloric.simulator.pyx` as a Cython extension in `seutp.py`. This helps out some package managers.

I had some issues properly installing this package. I use `pixi` as a environment manager and front-end to build packages. This did not automatically build the Cython extension. In addition, running `python setup.py build_ext` also does not build it, since it's not marked as an extension in `setup`. I didn't check whether or not this issue exists when using `pip` directly, as advertised in the readme. However, I suspect it's good practice anyways to mark Cython packages as such in the `setup.py`. I noticed they need the numpy headers to compile the `.c` file, hence the additional `include_dirs` argument in `setup`